### PR TITLE
Support multipart images

### DIFF
--- a/go/cmd/pngtile/main.go
+++ b/go/cmd/pngtile/main.go
@@ -47,36 +47,36 @@ func (options Options) imageParams() (pngtile.ImageParams, error) {
 	return imageParams, nil
 }
 
-func (options Options) run(path string) error {
-	log.Printf("%s", path)
+func (options Options) run(scanImage pngtile.ScanImage) error {
+	log.Printf("%s", scanImage.ImagePath)
 
-	return pngtile.WithImage(path, pngtile.OPEN_UPDATE, func(image *pngtile.Image) error {
-		if cacheStatus, err := image.Status(); err != nil {
+	return pngtile.WithImage(scanImage.CachePath, func(image *pngtile.Image) error {
+		if cacheStatus, err := image.Status(scanImage.ImagePath); err != nil {
 			return err
 		} else if cacheStatus != pngtile.CACHE_FRESH || options.Update {
-			log.Printf("%s: cache update (status %v)", path, cacheStatus)
+			log.Printf("%s: cache update (status %v)", scanImage.ImagePath, cacheStatus)
 
 			if imageParams, err := options.imageParams(); err != nil {
 				return err
-			} else if err := image.Update(imageParams); err != nil {
+			} else if err := image.Update(scanImage.ImagePath, imageParams); err != nil {
 				return err
 			}
 
 		} else {
-			log.Printf("%s: cache fresh", path)
+			log.Printf("%s: cache fresh", scanImage.ImagePath)
 
 			if err := image.Open(); err != nil {
 				return err
 			}
 		}
 
-		if info, err := image.Info(); err != nil {
+		if info, err := image.Info(scanImage.ImagePath); err != nil {
 			return err
 		} else {
-			fmt.Printf("%s:\n", path)
+			fmt.Printf("%s:\n", scanImage.CachePath)
 			fmt.Printf("\tImage: %dx%d@%d\n", info.ImageWidth, info.ImageHeight, info.ImageBPP)
-			fmt.Printf("\tImage mtime=%v bytes=%d\n", info.ImageModifiedTime, info.ImageBytes)
-			fmt.Printf("\tCache mtime=%v bytes=%d version=%d blocks=%d\n", info.CacheModifiedTime, info.CacheBytes, info.CacheVersion, info.CacheBlocks)
+			fmt.Printf("\tImage %s: mtime=%v bytes=%d\n", scanImage.ImagePath, info.ImageModifiedTime, info.ImageBytes)
+			fmt.Printf("\tCache %s: mtime=%v bytes=%d version=%d blocks=%d\n", scanImage.CachePath, info.CacheModifiedTime, info.CacheBytes, info.CacheVersion, info.CacheBlocks)
 
 			if options.TileRandom {
 				r := rand.New(rand.NewSource(time.Now().Unix()))
@@ -92,7 +92,7 @@ func (options Options) run(path string) error {
 			} else if err := ioutil.WriteFile(options.TileOut, tileData, 0644); err != nil {
 				return fmt.Errorf("Write --tile-out=%s: %v", options.TileOut, err)
 			} else {
-				log.Printf("%s: render %dx%d tile at %dx%d@%d to %s", path,
+				log.Printf("%s: render %dx%d tile at %dx%d@%d to %s", scanImage.ImagePath,
 					options.TileParams.Width,
 					options.TileParams.Height,
 					options.TileParams.X,
@@ -199,13 +199,17 @@ func main() {
 					return fmt.Errorf("scan %s: %v", arg, err)
 				} else {
 					for _, scanImage := range scanImages {
-						if err := options.run(scanImage.Path); err != nil {
-							return fmt.Errorf("%s: %s", scanImage.Path, err)
+						if err := options.run(scanImage); err != nil {
+							return fmt.Errorf("%s: %s", scanImage.ImagePath, err)
 						}
 					}
 				}
 			} else {
-				if err := options.run(arg); err != nil {
+				if scanImage, ok, err := pngtile.ScanFile(arg); err != nil {
+					return fmt.Errorf("scan %s: %v", arg, err)
+				} else if !ok {
+					return fmt.Errorf("scan %s: skipping", arg)
+				} else if err := options.run(scanImage); err != nil {
 					return fmt.Errorf("%s: %s", arg, err)
 				}
 			}

--- a/go/cmd/pngtile/main.go
+++ b/go/cmd/pngtile/main.go
@@ -73,7 +73,7 @@ func (options Options) run(scanImage pngtile.ScanImage) error {
 		if info, err := image.Info(); err != nil {
 			return err
 		} else {
-			fmt.Printf("%s:\n", scanImage.CachePath)
+			fmt.Printf("%s:\n", scanImage.ImagePath)
 			fmt.Printf("\tImage: %dx%d@%d\n", info.ImageWidth, info.ImageHeight, info.ImageBPP)
 			//fmt.Printf("\tImage %s: mtime=%v bytes=%d\n", scanImage.ImagePath, info.ImageModifiedTime, info.ImageBytes)
 			fmt.Printf("\tCache %s: mtime=%v bytes=%d version=%d blocks=%d\n", scanImage.CachePath, info.CacheModifiedTime, info.CacheBytes, info.CacheVersion, info.CacheBlocks)

--- a/go/cmd/pngtile/main.go
+++ b/go/cmd/pngtile/main.go
@@ -70,12 +70,12 @@ func (options Options) run(scanImage pngtile.ScanImage) error {
 			}
 		}
 
-		if info, err := image.Info(scanImage.ImagePath); err != nil {
+		if info, err := image.Info(); err != nil {
 			return err
 		} else {
 			fmt.Printf("%s:\n", scanImage.CachePath)
 			fmt.Printf("\tImage: %dx%d@%d\n", info.ImageWidth, info.ImageHeight, info.ImageBPP)
-			fmt.Printf("\tImage %s: mtime=%v bytes=%d\n", scanImage.ImagePath, info.ImageModifiedTime, info.ImageBytes)
+			//fmt.Printf("\tImage %s: mtime=%v bytes=%d\n", scanImage.ImagePath, info.ImageModifiedTime, info.ImageBytes)
 			fmt.Printf("\tCache %s: mtime=%v bytes=%d version=%d blocks=%d\n", scanImage.CachePath, info.CacheModifiedTime, info.CacheBytes, info.CacheVersion, info.CacheBlocks)
 
 			if options.TileRandom {

--- a/go/image.go
+++ b/go/image.go
@@ -39,12 +39,13 @@ func (image *Image) Status(path string) (CacheStatus, error) {
 
 func (image *Image) Info() (ImageInfo, error) {
 	var image_info C.struct_pt_image_info
+	var cache_info C.struct_pt_cache_info
 
-	if ret, err := C.pt_image_info(image.pt_image, &image_info); ret < 0 {
+	if ret, err := C.pt_image_info(image.pt_image, &cache_info, &image_info); ret < 0 {
 		return ImageInfo{}, makeError("pt_image_open", ret, err)
 	}
 
-	return makeImageInfo(&image_info), nil
+	return makeImageCacheInfo(&cache_info, &image_info), nil
 }
 
 // Open image cache in read-only mode

--- a/go/image.go
+++ b/go/image.go
@@ -60,22 +60,10 @@ func (image *Image) Status(path string) (CacheStatus, error) {
 	}
 }
 
-func (image *Image) Info(path string) (ImageInfo, error) {
-	var image_info C.struct_pt_image_info
-	var c_path = C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
-
-	if ret, err := C.pt_image_info(image.pt_image, c_path, &image_info); ret < 0 {
-		return ImageInfo{}, makeError("pt_image_open", ret, err)
-	}
-
-	return makeImageInfo(&image_info), nil
-}
-
-func (image *Image) CacheInfo() (ImageInfo, error) {
+func (image *Image) Info() (ImageInfo, error) {
 	var image_info C.struct_pt_image_info
 
-	if ret, err := C.pt_image_info(image.pt_image, nil, &image_info); ret < 0 {
+	if ret, err := C.pt_image_info(image.pt_image, &image_info); ret < 0 {
 		return ImageInfo{}, makeError("pt_image_open", ret, err)
 	}
 

--- a/go/image.go
+++ b/go/image.go
@@ -7,29 +7,6 @@ package pngtile
 import "C"
 import "unsafe"
 
-func imageSniff(path string) (ImageFormat, bool, error) {
-	var c_image_format C.enum_pt_image_format
-	var c_path = C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
-
-	if ret, err := C.pt_image_sniff(c_path, &c_image_format); ret < 0 {
-		return ImageFormat(ret), false, makeError("pt_image_sniff", ret, err)
-	} else {
-		return ImageFormat(c_image_format), ret == 0, nil
-	}
-}
-
-func cachePath(path string) (string, error) {
-	var c_path = C.CString(path)
-	var c_buf [1024]C.char
-
-	if ret, err := C.pt_cache_path(c_path, &c_buf[0], 1024); ret < 0 {
-		return "", makeError("pt_cache_path", ret, err)
-	} else {
-		return C.GoString(&c_buf[0]), nil
-	}
-}
-
 // mode: OPEN_*
 func imageOpen(cachePath string) (*Image, error) {
 	var image Image

--- a/go/image.go
+++ b/go/image.go
@@ -19,15 +19,25 @@ func imageSniff(path string) (ImageFormat, bool, error) {
 	}
 }
 
+func cachePath(path string) (string, error) {
+	var c_path = C.CString(path)
+	var c_buf [1024]C.char
+
+	if ret, err := C.pt_cache_path(c_path, &c_buf[0], 1024); ret < 0 {
+		return "", makeError("pt_cache_path", ret, err)
+	} else {
+		return C.GoString(&c_buf[0]), nil
+	}
+}
+
 // mode: OPEN_*
-func imageOpen(path string, mode OpenMode) (*Image, error) {
+func imageOpen(cachePath string) (*Image, error) {
 	var image Image
 
-	var c_path = C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
-	var c_mode = C.int(mode)
+	var c_cache_path = C.CString(cachePath)
+	defer C.free(unsafe.Pointer(c_cache_path))
 
-	if ret, err := C.pt_image_new(&image.pt_image, c_path, c_mode); ret < 0 {
+	if ret, err := C.pt_image_new(&image.pt_image, c_cache_path); ret < 0 {
 		return nil, makeError("pt_image_new", ret, err)
 	}
 
@@ -39,12 +49,37 @@ type Image struct {
 }
 
 // return: CACHE_*
-func (image *Image) Status() (CacheStatus, error) {
-	if ret, err := C.pt_image_status(image.pt_image); ret < 0 {
+func (image *Image) Status(path string) (CacheStatus, error) {
+	var c_path = C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
+
+	if ret, err := C.pt_image_status(image.pt_image, c_path); ret < 0 {
 		return CACHE_ERROR, makeError("pt_image_status", ret, err)
 	} else {
 		return CacheStatus(ret), nil
 	}
+}
+
+func (image *Image) Info(path string) (ImageInfo, error) {
+	var image_info C.struct_pt_image_info
+	var c_path = C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
+
+	if ret, err := C.pt_image_info(image.pt_image, c_path, &image_info); ret < 0 {
+		return ImageInfo{}, makeError("pt_image_open", ret, err)
+	}
+
+	return makeImageInfo(&image_info), nil
+}
+
+func (image *Image) CacheInfo() (ImageInfo, error) {
+	var image_info C.struct_pt_image_info
+
+	if ret, err := C.pt_image_info(image.pt_image, nil, &image_info); ret < 0 {
+		return ImageInfo{}, makeError("pt_image_open", ret, err)
+	}
+
+	return makeImageInfo(&image_info), nil
 }
 
 // Open image cache in read-only mode
@@ -57,24 +92,16 @@ func (image *Image) Open() error {
 }
 
 // Open image cache in update mode,
-func (image *Image) Update(params ImageParams) error {
+func (image *Image) Update(path string, params ImageParams) error {
 	var image_params = params.c_struct()
+	var c_path = C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
 
-	if ret, err := C.pt_image_update(image.pt_image, &image_params); ret < 0 {
+	if ret, err := C.pt_image_update(image.pt_image, c_path, &image_params); ret < 0 {
 		return makeError("pt_image_update", ret, err)
 	}
 
 	return nil
-}
-
-func (image *Image) Info() (ImageInfo, error) {
-	var image_info C.struct_pt_image_info
-
-	if ret, err := C.pt_image_info(image.pt_image, &image_info); ret < 0 {
-		return ImageInfo{}, makeError("pt_image_open", ret, err)
-	}
-
-	return makeImageInfo(&image_info), nil
 }
 
 // Render tile to PNG image

--- a/go/image_info.go
+++ b/go/image_info.go
@@ -12,16 +12,17 @@ func makeTime(t C.time_t) time.Time {
 	return time.Unix(int64(t), 0)
 }
 
-func makeImageInfo(ci *C.struct_pt_image_info) ImageInfo {
+func makeImageCacheInfo(ci *C.struct_pt_cache_info, ii *C.struct_pt_image_info) ImageInfo {
 	return ImageInfo{
-		ImageFormat:       ImageFormat(ci.format),
-		ImageWidth:        uint(ci.width),
-		ImageHeight:       uint(ci.height),
-		ImageBPP:          uint(ci.bpp),
-		CacheVersion:      int(ci.cache.version),
-		CacheModifiedTime: makeTime(ci.cache.mtime),
-		CacheBytes:        uint(ci.cache.bytes),
-		CacheBlocks:       uint(ci.cache.blocks),
+		ImageFormat: ImageFormat(ii.format),
+		ImageWidth:  uint(ii.width),
+		ImageHeight: uint(ii.height),
+		ImageBPP:    uint(ii.bpp),
+
+		CacheVersion:      int(ci.version),
+		CacheModifiedTime: makeTime(ci.mtime),
+		CacheBytes:        uint(ci.bytes),
+		CacheBlocks:       uint(ci.blocks),
 	}
 }
 

--- a/go/image_info.go
+++ b/go/image_info.go
@@ -14,17 +14,14 @@ func makeTime(t C.time_t) time.Time {
 
 func makeImageInfo(ci *C.struct_pt_image_info) ImageInfo {
 	return ImageInfo{
-		ImageFormat:       ImageFormat(ci.image_format),
-		ImageWidth:        uint(ci.image_width),
-		ImageHeight:       uint(ci.image_height),
-		ImageBPP:          uint(ci.image_bpp),
-		ImageModifiedTime: makeTime(ci.image_mtime),
-		ImageBytes:        uint(ci.image_bytes),
-		CacheVersion:      int(ci.cache_version),
-		CacheFormat:       ImageFormat(ci.cache_format),
-		CacheModifiedTime: makeTime(ci.cache_mtime),
-		CacheBytes:        uint(ci.cache_bytes),
-		CacheBlocks:       uint(ci.cache_blocks),
+		ImageFormat:       ImageFormat(ci.format),
+		ImageWidth:        uint(ci.width),
+		ImageHeight:       uint(ci.height),
+		ImageBPP:          uint(ci.bpp),
+		CacheVersion:      int(ci.cache.version),
+		CacheModifiedTime: makeTime(ci.cache.mtime),
+		CacheBytes:        uint(ci.cache.bytes),
+		CacheBlocks:       uint(ci.cache.blocks),
 	}
 }
 
@@ -33,9 +30,6 @@ type ImageInfo struct {
 	ImageWidth        uint        `json:"image_width"`
 	ImageHeight       uint        `json:"image_height"`
 	ImageBPP          uint        `json:"image_bpp"`
-	ImageModifiedTime time.Time   `json:"image_mtime"`
-	ImageBytes        uint        `json:"image_bytes"`
-	CacheFormat       ImageFormat `json:"cache_format"`
 	CacheVersion      int         `json:"cache_version"`
 	CacheModifiedTime time.Time   `json:"cache_mtime"`
 	CacheBytes        uint        `json:"cache_bytes"`

--- a/go/pngtile.go
+++ b/go/pngtile.go
@@ -1,13 +1,35 @@
 package pngtile
 
+/*
+#include <stdlib.h>
+#include "pngtile.h"
+*/
+import "C"
+import "unsafe"
+
 // Does this file look like a PNG file that we can use?
-func SniffImage(path string) (format ImageFormat, valid bool, err error) {
-	return imageSniff(path)
+func SniffImage(path string) (ImageFormat, bool, error) {
+	var c_image_format C.enum_pt_image_format
+	var c_path = C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
+
+	if ret, err := C.pt_sniff_image(c_path, &c_image_format); ret < 0 {
+		return ImageFormat(ret), false, makeError("pt_sniff_image", ret, err)
+	} else {
+		return ImageFormat(c_image_format), ret == 0, nil
+	}
 }
 
 // Convert PNG path to .cache path for use with Image
 func CachePath(path string) (string, error) {
-	return cachePath(path)
+	var c_path = C.CString(path)
+	var c_buf [1024]C.char
+
+	if ret, err := C.pt_cache_path(c_path, &c_buf[0], 1024); ret < 0 {
+		return "", makeError("pt_cache_path", ret, err)
+	} else {
+		return C.GoString(&c_buf[0]), nil
+	}
 }
 
 // Danger: must call image.Close() to not leak.

--- a/go/pngtile.go
+++ b/go/pngtile.go
@@ -5,16 +5,21 @@ func SniffImage(path string) (format ImageFormat, valid bool, err error) {
 	return imageSniff(path)
 }
 
+// Convert PNG path to .cache path for use with Image
+func CachePath(path string) (string, error) {
+	return cachePath(path)
+}
+
 // Danger: must call image.Close() to not leak.
-func OpenImage(path string, mode OpenMode) (*Image, error) {
-	return imageOpen(path, mode)
+func OpenImage(cachePath string) (*Image, error) {
+	return imageOpen(cachePath)
 }
 
 // Open image, and pass to func, or return error.
 //
 // Returns error from func, releasing the image.
-func WithImage(path string, mode OpenMode, f func(*Image) error) error {
-	if image, err := imageOpen(path, mode); err != nil {
+func WithImage(cachePath string, f func(*Image) error) error {
+	if image, err := imageOpen(cachePath); err != nil {
 		return err
 	} else {
 		defer image.destroy()

--- a/go/scan.go
+++ b/go/scan.go
@@ -1,8 +1,12 @@
 package pngtile
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -22,9 +26,10 @@ func (scanOptions ScanOptions) filter(scanImage ScanImage) bool {
 }
 
 type ScanImage struct {
-	ImagePath string
-	CachePath string
-	Format    ImageFormat
+	ImagePath  string
+	ImagePaths [][]string
+	CachePath  string
+	Format     ImageFormat
 }
 
 func (scanImage ScanImage) IsCache() bool {
@@ -82,4 +87,83 @@ func Scan(root string, options ScanOptions) ([]ScanImage, error) {
 
 		return nil
 	})
+}
+
+type scanPart struct {
+	path, ext string
+	row, col  int
+}
+
+func ScanParts(paths []string, pattern *regexp.Regexp) (ScanImage, error) {
+	var scanImage ScanImage
+	var path, ext string
+	var partsMap = make(map[scanPart]string)
+	var rows = 0
+	var cols = 0
+
+	for _, p := range paths {
+		var scanPart scanPart
+
+		if matches := pattern.FindStringSubmatch(p); matches == nil {
+			log.Printf("scan path %s: skip", p)
+			// skip
+			continue
+		} else {
+			scanPart.path = matches[1]
+			scanPart.ext = matches[4]
+
+			if row, err := strconv.ParseInt(matches[2], 0, 0); err != nil {
+				return scanImage, fmt.Errorf("Invalid row for path %s: %s", p, err)
+			} else {
+				scanPart.row = int(row)
+			}
+
+			if col, err := strconv.ParseInt(matches[3], 0, 0); err != nil {
+				return scanImage, fmt.Errorf("Invalid col for path %s: %s", p, err)
+			} else {
+				scanPart.col = int(col)
+			}
+		}
+
+		if imageFormat, ok, err := SniffImage(p); err != nil {
+			return scanImage, fmt.Errorf("Failed image %s: %s", p, err)
+		} else if !ok {
+			return scanImage, fmt.Errorf("Invalid image %s", p)
+		} else {
+			scanImage.Format = imageFormat
+		}
+
+		log.Printf("scan path %s: %#v", p, scanPart)
+
+		partsMap[scanPart] = p
+
+		path = scanPart.path
+		ext = scanPart.ext
+
+		if scanPart.row > rows {
+			rows = scanPart.row
+		}
+		if scanPart.col > cols {
+			cols = scanPart.col
+		}
+	}
+
+	scanImage.ImagePath = path + "." + ext
+	scanImage.ImagePaths = make([][]string, rows)
+
+	for row := 0; row < rows; row++ {
+		scanImage.ImagePaths[row] = make([]string, cols)
+
+		for col := 0; col < cols; col++ {
+			scanImage.ImagePaths[row][col] = partsMap[scanPart{path, ext, row + 1, col + 1}]
+		}
+	}
+
+	if cachePath, err := CachePath(scanImage.ImagePath); err != nil {
+		return scanImage, err
+	} else {
+		scanImage.CachePath = cachePath
+	}
+
+	return scanImage, nil
 }

--- a/go/server/http_image.go
+++ b/go/server/http_image.go
@@ -28,13 +28,13 @@ func (server *Server) HandleImage(r *http.Request, name string) (httpResponse, e
 		return renderResponse(r, server.templates.imageTemplate, ImageResponse{
 			Name: name,
 			Config: ImageConfig{
-				URL:          server.URL(name + "." + imageInfo.CacheFormat.String()),
+				URL:          server.URL(name + "." + imageInfo.ImageFormat.String()),
 				ModifiedTime: 0, // TODO: caching
 				TileURL:      TileURLTemplate,
 				TileSize:     TileSize,
 				TileZoom:     TileZoomMax,
 				ViewURL:      ViewURLTemplate,
-				ImageFormat:  imageInfo.CacheFormat.String(),
+				ImageFormat:  imageInfo.ImageFormat.String(),
 				ImageWidth:   imageInfo.ImageWidth,
 				ImageHeight:  imageInfo.ImageHeight,
 			},

--- a/go/server/http_index.go
+++ b/go/server/http_index.go
@@ -46,7 +46,7 @@ func (item IndexImage) ImageURL() string {
 		Y:      item.imageInfo.ImageHeight / 2,
 	}
 
-	if tileURL, err := TileURL(item.Name, item.imageInfo.CacheFormat, tileParams); err != nil {
+	if tileURL, err := TileURL(item.Name, item.imageInfo.ImageFormat, tileParams); err != nil {
 		return ""
 	} else {
 		return tileURL

--- a/go/server/image.go
+++ b/go/server/image.go
@@ -76,7 +76,7 @@ func (server *Server) openImage(name string) (*Image, error) {
 		return nil, err
 	} else if err := pngtileImage.Open(); err != nil {
 		return nil, err
-	} else if pngtileInfo, err := pngtileImage.CacheInfo(); err != nil {
+	} else if pngtileInfo, err := pngtileImage.Info(); err != nil {
 		return nil, err
 	} else {
 		var image = Image{

--- a/go/server/image.go
+++ b/go/server/image.go
@@ -48,7 +48,7 @@ func (server *Server) Images(name string) ([]string, error) {
 		var names = make([]string, 0)
 
 		for _, scanImage := range scanImages {
-			var name = scanImage.Path
+			var name = scanImage.CachePath
 
 			// relative to server path
 			name = strings.TrimPrefix(name, server.path)
@@ -72,11 +72,11 @@ type Image struct {
 func (server *Server) openImage(name string) (*Image, error) {
 	if path, err := server.Path(name, ".cache"); err != nil {
 		return nil, err
-	} else if pngtileImage, err := pngtile.OpenImage(path, pngtile.OPEN_READ); err != nil {
+	} else if pngtileImage, err := pngtile.OpenImage(path); err != nil {
 		return nil, err
 	} else if err := pngtileImage.Open(); err != nil {
 		return nil, err
-	} else if pngtileInfo, err := pngtileImage.Info(); err != nil {
+	} else if pngtileInfo, err := pngtileImage.CacheInfo(); err != nil {
 		return nil, err
 	} else {
 		var image = Image{

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -53,7 +53,7 @@ func (server *Server) Path(url, suffix string) (string, error) {
 	return path, nil
 }
 
-func (server *Server) Lookup(url string, defaultExt string) (path, name, ext string, err error) {
+func (server *Server) Lookup(url string, forceExt string) (path, name, ext string, err error) {
 	var dir, base string
 
 	if url == "" {
@@ -81,11 +81,13 @@ func (server *Server) Lookup(url string, defaultExt string) (path, name, ext str
 		}
 	}
 
-	path, err = server.Path(url, "")
+	var suffix = ""
 
-	if base != "" && ext == "" {
-		path = path + "." + defaultExt
+	if base != "" || ext != "" {
+		suffix = "." + forceExt
 	}
+
+	path, err = server.Path(name, suffix)
 
 	return path, name, ext, err
 }

--- a/include/pngtile.h
+++ b/include/pngtile.h
@@ -54,35 +54,34 @@ enum pt_image_format {
     PT_FORMAT_PNG,
 };
 
-/** Metadata info for image. Values will be set to zero if not available */
+/** Metadata for cache file */
+struct pt_cache_info {
+  /** Last update of cache file */
+  time_t mtime;
+
+  /** Size of cache file in bytes */
+  size_t bytes;
+
+  /** Size of cache file in blocks (for sparse cache files) - 512 bytes / block? */
+  size_t blocks;
+
+  /** Cache format version or -err */
+  int version;
+};
+
+/** Common metadata info for image/cache file */
 struct pt_image_info {
-    enum pt_image_format image_format;
+  /** Cache file metadata */
+  struct pt_cache_info cache;
 
-    /** Dimensions of image. Only available if the cache is open */
-    size_t image_width, image_height;
+  /** Image format */
+  enum pt_image_format format;
 
-    /** Bits per pixel */
-    size_t image_bpp;
+  /** Dimensions of image. Only available if the cache is open */
+  size_t width, height;
 
-    /** Last update of image file */
-    time_t image_mtime;
-
-    /** Size of image file in bytes */
-    size_t image_bytes;
-
-    /** Cache format version or -err */
-    int cache_version;
-
-    enum pt_image_format cache_format;
-
-    /** Last update of cache file */
-    time_t cache_mtime;
-
-    /** Size of cache file in bytes */
-    size_t cache_bytes;
-
-    /** Size of cache file in blocks (for sparse cache files) - 512 bytes / block? */
-    size_t cache_blocks;
+  /** Bits per pixel */
+  size_t bpp;
 };
 
 /**
@@ -173,9 +172,9 @@ int pt_image_new (struct pt_image **image_ptr, const char *cache_path);
 int pt_image_status (struct pt_image *image, const char *path);
 
 /**
- * Get the given source image's metadata from the cache file.
+ * Get the cache metadata.
  */
-int pt_image_info (struct pt_image *image, const char *path, struct pt_image_info *info_ptr);
+int pt_image_info (struct pt_image *image, struct pt_image_info *info);
 
 /**
  * Update the cache from the given source image.

--- a/include/pngtile.h
+++ b/include/pngtile.h
@@ -77,7 +77,7 @@ struct pt_image_info {
   /** Image format */
   enum pt_image_format format;
 
-  /** Dimensions of image. Only available if the cache is open */
+  /** Dimensions of image */
   size_t width, height;
 
   /** Bits per pixel */

--- a/include/pngtile.h
+++ b/include/pngtile.h
@@ -140,13 +140,11 @@ extern bool pt_log_warn;
 /**
  * Test if the given file looks like something that you can open.
  *
- * No point calling this before pt_image_new, which already calls this.
- *
  * @param format return detected format if 0
  * @return 0 if ok
  * @return 1 if unknown
  */
-int pt_image_sniff (const char *path, enum pt_image_format *format);
+int pt_sniff_image (const char *path, enum pt_image_format *format);
 
 /**
  * Build a filesystem path representing the appropriate path for an image's cache file, and store it in the given

--- a/include/pngtile.h
+++ b/include/pngtile.h
@@ -71,9 +71,6 @@ struct pt_cache_info {
 
 /** Common metadata info for image/cache file */
 struct pt_image_info {
-  /** Cache file metadata */
-  struct pt_cache_info cache;
-
   /** Image format */
   enum pt_image_format format;
 
@@ -172,7 +169,7 @@ int pt_image_status (struct pt_image *image, const char *path);
 /**
  * Get the cache metadata.
  */
-int pt_image_info (struct pt_image *image, struct pt_image_info *info);
+int pt_image_info (struct pt_image *image, struct pt_cache_info *cache_info, struct pt_image_info *info);
 
 /**
  * Update the cache from the given source image.

--- a/include/pngtile.h
+++ b/include/pngtile.h
@@ -144,6 +144,15 @@ extern bool pt_log_warn;
 int pt_sniff_image (const char *path, enum pt_image_format *format);
 
 /**
+ * Read basic image metadata from source file.
+ *
+ * @param info return detected format + metadata
+ * @return 0 if ok
+ * @return 1 if unknown format
+ */
+int pt_read_image_info (const char *path, struct pt_image_info *info);
+
+/**
  * Build a filesystem path representing the appropriate path for an image's cache file, and store it in the given
  * buffer.
  *

--- a/include/pngtile.h
+++ b/include/pngtile.h
@@ -107,6 +107,17 @@ struct pt_image_params {
 };
 
 /**
+ * Multi-part image update.
+ */
+struct pt_image_parts {
+  enum pt_image_format format;
+
+  unsigned int rows, cols;
+
+  const char **paths;
+};
+
+/**
  * Parameters for tile render.
  *
  * The tile may safely overlap with the edge of the image, but it should not be entirely outside of the image
@@ -185,9 +196,20 @@ int pt_image_info (struct pt_image *image, struct pt_cache_info *cache_info, str
  *
  * Also opens the image.
  *
+ * @param path path to source image file
  * @param params optional parameters to use for the update process
  */
 int pt_image_update (struct pt_image *image, const char *path, const struct pt_image_params *params);
+
+/**
+ * Update the cache from multiple tiled source images.
+ *
+ * Also opens the image.
+ *
+ * @param path paths to source image files, all of the same format
+ * @param params optional parameters to use for the update process
+ */
+int pt_image_update_parts (struct pt_image *image, const struct pt_image_parts *parts, const struct pt_image_params *params);
 
 /**
  * Load the image's cache in read-only mode without trying to update it.
@@ -258,6 +280,7 @@ enum pt_error {
 
     PT_ERR_PNG_CREATE,
     PT_ERR_PNG,
+    PT_ERR_PNG_FORMAT,
 
     PT_ERR_CACHE_MODE,
     PT_ERR_CACHE_STAT,

--- a/src/lib/cache.c
+++ b/src/lib/cache.c
@@ -217,24 +217,28 @@ int pt_read_cache_info (const char *path, struct pt_image_info *info)
     }
 
     // cache file info
-    info->cache_mtime = st.st_mtime;
-    info->cache_bytes = st.st_size;
-    info->cache_blocks = st.st_blocks;
+    info->cache.mtime = st.st_mtime;
+    info->cache.bytes = st.st_size;
+    info->cache.blocks = st.st_blocks;
 
     // read header
     if ((err = pt_read_cache_header(path, &header)))
         return err;
 
-    info->cache_format = header.format;
-    info->cache_version = header.version;
+    info->cache.version = header.version;
 
     // image info
+    info->format = header.format;
+
     switch (header.format) {
       case PT_FORMAT_CACHE:
         return -PT_ERR_CACHE_FORMAT;
 
       case PT_FORMAT_PNG:
-        pt_png_info(&header.png, info);
+        info->width = header.png.width;
+        info->height = header.png.height;
+        info->bpp = header.png.bit_depth;
+
         break;
 
     }

--- a/src/lib/cache.c
+++ b/src/lib/cache.c
@@ -154,7 +154,7 @@ error:
   return err;
 }
 
-int pt_check_cache (const char *path)
+int pt_sniff_cache (const char *path)
 {
   struct pt_cache_header header;
   int ret;

--- a/src/lib/cache.c
+++ b/src/lib/cache.c
@@ -206,26 +206,31 @@ int pt_stat_cache (const char *path, const char *img_path)
     return PT_CACHE_FRESH;
 }
 
-int pt_read_cache_info (const char *path, struct pt_image_info *info)
+int pt_read_cache_info (const char *path, struct pt_cache_info *cache_info, struct pt_image_info *info)
 {
     struct pt_cache_header header;
     int err = 0;
-    struct stat st;
 
-    if (stat(path, &st) < 0) {
-      return -PT_ERR_CACHE_STAT;
+    if (cache_info) {
+      struct stat st;
+
+      if (stat(path, &st) < 0) {
+        return -PT_ERR_CACHE_STAT;
+      }
+
+      // cache file info
+      cache_info->mtime = st.st_mtime;
+      cache_info->bytes = st.st_size;
+      cache_info->blocks = st.st_blocks;
     }
-
-    // cache file info
-    info->cache.mtime = st.st_mtime;
-    info->cache.bytes = st.st_size;
-    info->cache.blocks = st.st_blocks;
 
     // read header
     if ((err = pt_read_cache_header(path, &header)))
         return err;
 
-    info->cache.version = header.version;
+    if (cache_info) {
+      cache_info->version = header.version;
+    }
 
     // image info
     info->format = header.format;

--- a/src/lib/cache.c
+++ b/src/lib/cache.c
@@ -16,9 +16,28 @@ const uint16_t pt_cache_version = PT_CACHE_VERSION;
 const uint8_t pt_cache_magic[6] = PT_CACHE_MAGIC;
 
 /**
+ * Compute and return the full size of the .cache file
+ */
+static inline size_t sizeof_pt_cache_file (size_t data_size)
+{
+    assert(sizeof(struct pt_cache_file) == PT_CACHE_HEADER_SIZE);
+
+    return sizeof(struct pt_cache_file) + data_size;
+}
+
+int pt_cache_path (const char *path, char *buf, size_t len)
+{
+    if (pt_path_make_ext(buf, len, path, ".cache")) {
+        return -PT_ERR_PATH;
+    }
+
+    return 0;
+}
+
+/**
  * Open the cache file as an fd for reading
  */
-static int pt_cache_open_read_fd (const char *path, int *fd_ptr)
+static int pt_open_cache_read_fd (const char *path, int *fd_ptr)
 {
     PT_DEBUG("%s", path);
 
@@ -26,7 +45,7 @@ static int pt_cache_open_read_fd (const char *path, int *fd_ptr)
 
     // actual open()
     if ((fd = open(path, O_RDONLY)) < 0)
-        return -PT_ERR_OPEN_MODE;
+        return -PT_ERR_CACHE_OPEN_READ;
 
     // ok
     *fd_ptr = fd;
@@ -37,7 +56,7 @@ static int pt_cache_open_read_fd (const char *path, int *fd_ptr)
 /**
  * Read in the cache header from the open file
  */
-static int pt_cache_read_header (int fd, struct pt_cache_header *header)
+static int pt_cache_header_read (struct pt_cache_header *header, int fd)
 {
     size_t len = sizeof(*header);
     char *buf = (char *) header;
@@ -64,9 +83,38 @@ static int pt_cache_read_header (int fd, struct pt_cache_header *header)
 }
 
 /**
+ * Write out the cache header into the opened file
+ */
+static int pt_cache_header_write (const struct pt_cache_header *header, int fd)
+{
+    size_t len = sizeof(*header);
+    const char *buf = (const char *) header;
+
+    // seek to start
+    if (lseek(fd, 0, SEEK_SET) != 0)
+        return -PT_ERR_CACHE_SEEK;
+
+    // write out full header
+    while (len) {
+        ssize_t ret;
+
+        // try and write out the header
+        if ((ret = write(fd, buf, len)) <= 0)
+            return -PT_ERR_CACHE_WRITE;
+
+        // update offset
+        buf += ret;
+        len -= ret;
+    }
+
+    // done
+    return 0;
+}
+
+/**
  * Validate header: magic, version, format
  */
-static int pt_cache_check_header (const struct pt_cache_header *header)
+static int pt_cache_header_check (const struct pt_cache_header *header)
 {
   PT_DEBUG("magic=%6.6s version=%d format=%d", header->magic, header->version, header->format);
 
@@ -89,32 +137,114 @@ static int pt_cache_check_header (const struct pt_cache_header *header)
   return 0;
 }
 
-int pt_cache_check (const char *path)
+static int pt_read_cache_header (const char *path, struct pt_cache_header *header)
 {
   int fd;
-  struct pt_cache_header header;
-  int ret;
+  int err;
 
-  if ((ret = pt_cache_open_read_fd(path, &fd)))
-      return ret;
+  if ((err = pt_open_cache_read_fd(path, &fd)))
+      return err;
 
-  if ((ret = pt_cache_read_header(fd, &header)))
+  if ((err = pt_cache_header_read(header, fd)))
       goto error; // XXX: return 1 on EOF / short header?
-
-  if ((ret = pt_cache_check_header(&header))) {
-      ret = 1;
-      goto error;
-  }
 
 error:
   close(fd);
 
-  return ret;
+  return err;
 }
 
-int pt_cache_new (struct pt_cache **cache_ptr, const char *path, int mode)
+int pt_check_cache (const char *path)
 {
-    PT_DEBUG("%s: mode=%d", path, mode);
+  struct pt_cache_header header;
+  int ret;
+
+  if ((ret = pt_read_cache_header(path, &header)))
+    return ret;
+
+  if ((ret = pt_cache_header_check(&header)))
+    return ret;
+
+  return 0;
+}
+
+int pt_stat_cache (const char *path, const char *img_path)
+{
+    PT_DEBUG("%s <=> %s", path, img_path);
+
+    struct pt_cache_header header;
+    struct stat st_img, st_cache;
+    int err = 0;
+
+    // test original file
+    if (stat(img_path, &st_img) < 0)
+        return -PT_ERR_IMG_STAT;
+
+    // test cache file
+    if (stat(path, &st_cache) < 0) {
+        // always stale if it doesn't exist yet
+        if (errno == ENOENT)
+            return PT_CACHE_NONE;
+        else
+            return -PT_ERR_CACHE_STAT;
+    }
+
+    // compare mtime
+    if (st_img.st_mtime > st_cache.st_mtime)
+        return PT_CACHE_STALE;
+
+    // read header
+    if ((err = pt_read_cache_header(path, &header))) {
+        return err;
+    }
+
+    // check version, magic, format
+    if ((err = pt_cache_header_check(&header)))
+        return PT_CACHE_INCOMPAT;
+
+    // ok, should be in order
+    return PT_CACHE_FRESH;
+}
+
+int pt_read_cache_info (const char *path, struct pt_image_info *info)
+{
+    struct pt_cache_header header;
+    int err = 0;
+    struct stat st;
+
+    if (stat(path, &st) < 0) {
+      return -PT_ERR_CACHE_STAT;
+    }
+
+    // cache file info
+    info->cache_mtime = st.st_mtime;
+    info->cache_bytes = st.st_size;
+    info->cache_blocks = st.st_blocks;
+
+    // read header
+    if ((err = pt_read_cache_header(path, &header)))
+        return err;
+
+    info->cache_format = header.format;
+    info->cache_version = header.version;
+
+    // image info
+    switch (header.format) {
+      case PT_FORMAT_CACHE:
+        return -PT_ERR_CACHE_FORMAT;
+
+      case PT_FORMAT_PNG:
+        pt_png_info(&header.png, info);
+        break;
+
+    }
+
+    return 0;
+}
+
+int pt_cache_new (struct pt_cache **cache_ptr, const char *path)
+{
+    PT_DEBUG("%s", path);
 
     struct pt_cache *cache;
     int err;
@@ -130,7 +260,6 @@ int pt_cache_new (struct pt_cache **cache_ptr, const char *path, int mode)
 
     // init
     cache->fd = -1;
-    cache->mode = mode;
 
     // ok
     *cache_ptr = cache;
@@ -153,8 +282,8 @@ static void pt_cache_abort (struct pt_cache *cache)
     PT_DEBUG("%s", cache->path);
 
     if (cache->file != NULL) {
-        if (munmap(cache->file, sizeof(struct pt_cache_file) + cache->file->header.data_size))
-            PT_WARN_ERRNO("munmap %p, %zu", cache->file, sizeof(struct pt_cache_file) + cache->file->header.data_size);
+        if (munmap(cache->file, sizeof_pt_cache_file(cache->file->header.data_size)))
+            PT_WARN_ERRNO("munmap %p, %zu", cache->file, sizeof_pt_cache_file(cache->file->header.data_size));
 
         cache->file = NULL;
     }
@@ -167,105 +296,6 @@ static void pt_cache_abort (struct pt_cache *cache)
     }
 }
 
-/**
- * Read the header from the cache file, temporarily opening it if needed.
- *
- * Does not check if the header is valid; call pt_cache_check_header()!
- */
-static int pt_cache_header (struct pt_cache *cache, struct pt_cache_header *header)
-{
-    // already open?
-    if (cache->file) {
-        *header = cache->file->header;
-        return 0;
-    }
-
-    int fd;
-    int err = 0;
-
-    // temp. open
-    if ((err = pt_cache_open_read_fd(cache->path, &fd)))
-        return err;
-
-    // read header
-    if ((err = pt_cache_read_header(fd, header)))
-        goto error;
-
-error:
-    // close
-    close(fd);
-
-    PT_DEBUG("%s: %d", cache->path, err);
-
-    return err;
-}
-
-int pt_cache_status (struct pt_cache *cache, const char *img_path)
-{
-    PT_DEBUG("%s", cache->path);
-
-    struct pt_cache_header header;
-    struct stat st_img, st_cache;
-    int err = 0;
-
-    // test original file
-    if (stat(img_path, &st_img) < 0)
-        return -PT_ERR_IMG_STAT;
-
-    // test cache file
-    if (stat(cache->path, &st_cache) < 0) {
-        // always stale if it doesn't exist yet
-        if (errno == ENOENT)
-            return PT_CACHE_NONE;
-        else
-            return -PT_ERR_CACHE_STAT;
-    }
-
-    // compare mtime
-    if (st_img.st_mtime > st_cache.st_mtime)
-        return PT_CACHE_STALE;
-
-    // read header
-    if ((err = pt_cache_header(cache, &header))) {
-        return err;
-    }
-
-    // check version, magic, format
-    if ((err = pt_cache_check_header(&header)))
-        return PT_CACHE_INCOMPAT;
-
-    // ok, should be in order
-    return PT_CACHE_FRESH;
-}
-
-int pt_cache_info (struct pt_cache *cache, struct pt_image_info *info)
-{
-    struct pt_cache_header header;
-    int err = 0;
-    struct stat st;
-
-    if (stat(cache->path, &st) < 0) {
-      return -PT_ERR_CACHE_STAT;
-    }
-
-    // cache file info
-    info->cache_mtime = st.st_mtime;
-    info->cache_bytes = st.st_size;
-    info->cache_blocks = st.st_blocks;
-
-    // read header
-    if ((err = pt_cache_header(cache, &header)))
-        return err;
-
-    info->cache_format = header.format;
-    info->cache_version = header.version;
-
-    // img info
-    pt_png_info(&header.png, info);
-
-    return 0;
-}
-
 static int pt_cache_tmp_name (struct pt_cache *cache, char tmp_path[], size_t tmp_len)
 {
     // get .tmp path
@@ -273,16 +303,6 @@ static int pt_cache_tmp_name (struct pt_cache *cache, char tmp_path[], size_t tm
         return -PT_ERR_PATH;
 
     return 0;
-}
-
-/**
- * Compute and return the full size of the .cache file
- */
-static size_t pt_cache_size (size_t data_size)
-{
-    assert(sizeof(struct pt_cache_file) == PT_CACHE_HEADER_SIZE);
-
-    return sizeof(struct pt_cache_file) + data_size;
 }
 
 /**
@@ -314,9 +334,9 @@ static int pt_cache_open_tmp_fd (struct pt_cache *cache, int *fd_ptr)
 
 
 /**
- * Mmap the pt_cache_file using pt_cache_size(data_size)
+ * Mmap the pt_cache_file using sizeof_pt_cache_file(data_size)
  */
-static int pt_cache_open_mmap (struct pt_cache *cache, struct pt_cache_file **file_ptr, size_t data_size, bool readonly)
+static int pt_cache_open_mmap (struct pt_cache *cache, size_t data_size, bool readonly)
 {
     int prot = 0;
     void *addr;
@@ -325,17 +345,16 @@ static int pt_cache_open_mmap (struct pt_cache *cache, struct pt_cache_file **fi
     prot |= PROT_READ;
 
     if (!readonly) {
-        assert(cache->mode & PT_OPEN_UPDATE);
-
         prot |= PROT_WRITE;
     }
 
     // mmap() the full file including header
-    if ((addr = mmap(NULL, pt_cache_size(data_size), prot, MAP_SHARED, cache->fd, 0)) == MAP_FAILED)
+    if ((addr = mmap(NULL, sizeof_pt_cache_file(data_size), prot, MAP_SHARED, cache->fd, 0)) == MAP_FAILED)
         return -PT_ERR_CACHE_MMAP;
 
     // ok
-    *file_ptr = addr;
+    cache->file = addr;
+    cache->readonly = readonly;
 
     return 0;
 }
@@ -351,19 +370,21 @@ int pt_cache_open (struct pt_cache *cache)
     if (cache->file)
         return 0;
 
+    PT_DEBUG("%s", cache->path);
+
     // open the .cache in readonly mode
-    if ((err = pt_cache_open_read_fd(cache->path, &cache->fd)))
+    if ((err = pt_open_cache_read_fd(cache->path, &cache->fd)))
         return err;
 
     // read in header
-    if ((err = pt_cache_read_header(cache->fd, &header)))
+    if ((err = pt_cache_header_read(&header, cache->fd)))
         goto error;
 
-    if ((err = pt_cache_check_header(&header)))
+    if ((err = pt_cache_header_check(&header)))
         goto error;
 
     // mmap the header + data
-    if ((err = pt_cache_open_mmap(cache, &cache->file, header.data_size, true)))
+    if ((err = pt_cache_open_mmap(cache, header.data_size, true)))
         goto error;
 
     // done
@@ -377,59 +398,34 @@ error:
 }
 
 /**
- * Write out the cache header into the opened file
- */
-static int pt_cache_write_header (struct pt_cache *cache, const struct pt_cache_header *header)
-{
-    size_t len = sizeof(*header);
-    const char *buf = (const char *) header;
-
-    // seek to start
-    if (lseek(cache->fd, 0, SEEK_SET) != 0)
-        return -PT_ERR_CACHE_SEEK;
-
-    // write out full header
-    while (len) {
-        ssize_t ret;
-
-        // try and write out the header
-        if ((ret = write(cache->fd, buf, len)) <= 0)
-            return -PT_ERR_CACHE_WRITE;
-
-        // update offset
-        buf += ret;
-        len -= ret;
-    }
-
-    // done
-    return 0;
-}
-
-/**
  * Create a new .tmp cache file, open it, and write out the header.
  */
 static int pt_cache_create (struct pt_cache *cache, struct pt_cache_header *header)
 {
     int err;
 
-    assert(cache->mode & PT_OPEN_UPDATE);
+    if (cache->file) {
+      return -PT_ERR_CACHE_MODE;
+    }
+
+    PT_DEBUG("%s: data_size=%zu", cache->path, header->data_size);
 
     // open as .tmp
     if ((err = pt_cache_open_tmp_fd(cache, &cache->fd)))
         return err;
 
     // write header
-    if ((err = pt_cache_write_header(cache, header)))
+    if ((err = pt_cache_header_write(header, cache->fd)))
         goto error;
 
     // grow file
-    if (ftruncate(cache->fd, pt_cache_size(header->data_size)) < 0) {
+    if (ftruncate(cache->fd, sizeof_pt_cache_file(header->data_size)) < 0) {
         err = -PT_ERR_CACHE_TRUNC;
         goto error;
       }
 
     // mmap header and data
-    if ((err = pt_cache_open_mmap(cache, &cache->file, header->data_size, false)))
+    if ((err = pt_cache_open_mmap(cache, header->data_size, false)))
       goto error;
 
     // done
@@ -494,13 +490,9 @@ int pt_cache_update_png (struct pt_cache *cache, struct pt_png_img *img, const s
     };
     int err;
 
-    // check mode
-    if (!(cache->mode & PT_OPEN_UPDATE))
-        return -PT_ERR_OPEN_MODE;
-
-    // close if open
-    if ((err = pt_cache_close(cache)))
-        return err;
+    if (cache->file) {
+      return -PT_ERR_CACHE_MODE;
+    }
 
     // read img header
     if ((err = pt_png_read_header(img, &header.png, &header.data_size)))
@@ -535,13 +527,13 @@ int pt_cache_render_tile (struct pt_cache *cache, struct pt_tile *tile)
 {
     int err;
 
+    if (!cache->file) {
+      return -PT_ERR_CACHE_MODE;
+    }
+
     // validate params
     if (!tile->params.width || !tile->params.height)
         return -PT_ERR_TILE_DIM;
-
-    // ensure open
-    if ((err = pt_cache_open(cache)))
-        return err;
 
     // render
     if ((err = pt_png_tile(&cache->file->header.png, cache->file->data, tile)))
@@ -552,6 +544,8 @@ int pt_cache_render_tile (struct pt_cache *cache, struct pt_tile *tile)
 
 int pt_cache_close (struct pt_cache *cache)
 {
+    PT_DEBUG("%s", cache->path);
+
     if (cache->file != NULL) {
         if (munmap(cache->file, sizeof(struct pt_cache_file) + cache->file->header.data_size))
             return -PT_ERR_CACHE_MUNMAP;

--- a/src/lib/cache.h
+++ b/src/lib/cache.h
@@ -63,7 +63,7 @@ struct pt_cache_file {
  * @return 0 if valid cache file
  * @return 1 if not a valid cache file
  */
-int pt_check_cache (const char *path);
+int pt_sniff_cache (const char *path);
 
 /**
  * Verify if the cached data eixsts, or has become stale compared to the given original file.

--- a/src/lib/cache.h
+++ b/src/lib/cache.h
@@ -112,9 +112,29 @@ struct pt_cache {
 int pt_cache_new (struct pt_cache **cache_ptr, const char *path);
 
 /**
+ * initialize new cache file for PNG header.
+ */
+int pt_cache_create_png (struct pt_cache *cache, const struct pt_png_header *png_header, const struct pt_image_params *params);
+
+/**
  * Update the cache data from the given PNG image data
  */
-int pt_cache_update_png (struct pt_cache *cache, struct pt_png_img *img, const struct pt_image_params *params);
+int pt_cache_update_png (struct pt_cache *cache, struct pt_png_img *img, const struct pt_png_header *header, const struct pt_image_params *params);
+
+/**
+ * Update partial cache data from the given PNG image data
+ */
+int pt_cache_update_png_part (struct pt_cache *cache, struct pt_png_img *img, const struct pt_png_header *header, const struct pt_image_params *params, unsigned row, unsigned col);
+
+/**
+ * Rename the opened .tmp to .cache
+ */
+int pt_cache_create_done (struct pt_cache *cache);
+
+/**
+ * Abort a failed cache update after cache_create
+ */
+void pt_cache_create_abort (struct pt_cache *cache);
 
 /**
  * Open the existing .cache for use. If already opened, does nothing.

--- a/src/lib/cache.h
+++ b/src/lib/cache.h
@@ -79,10 +79,12 @@ int pt_stat_cache (const char *path, const char *img_path);
  *
  * Opens the cache temporarily if not already opened.
  *
+ * @param cache_info optional
+ * @param info returned info
  * @return from pt_cache_header()
  * @return -PT_ERR_CACHE_STAT
  */
-int pt_read_cache_info (const char *path, struct pt_image_info *info);
+ int pt_read_cache_info (const char *path, struct pt_cache_info *cache_info, struct pt_image_info *info);
 
 /**
  * Cache state

--- a/src/lib/cache.h
+++ b/src/lib/cache.h
@@ -57,38 +57,13 @@ struct pt_cache_file {
 };
 
 /**
- * Cache state
- */
-struct pt_cache {
-    /** Filesystem path to cache file */
-    char *path;
-
-    /** The mode we are operating in, bitmask of PT_IMG_* */
-    int mode;
-
-    /** Opened file */
-    int fd;
-
-    /** Size of the data segment in bytes, starting at PT_CACHE_HEADER_SIZE */
-    size_t data_size;
-
-    /** The mmap'd file */
-    struct pt_cache_file *file;
-};
-
-/**
  * Check if given file is a cache file.
  *
  * @return <0 on error
  * @return 0 if valid cache file
  * @return 1 if not a valid cache file
  */
-int pt_cache_check (const char *path);
-
-/**
- * Construct the image cache info object associated with the given image.
- */
-int pt_cache_new (struct pt_cache **cache_ptr, const char *path, int mode);
+int pt_check_cache (const char *path);
 
 /**
  * Verify if the cached data eixsts, or has become stale compared to the given original file.
@@ -97,7 +72,7 @@ int pt_cache_new (struct pt_cache **cache_ptr, const char *path, int mode);
  *
  * @return one of pt_cache_status; <0 on error, 0 if fresh, >0 otherwise
  */
-int pt_cache_status (struct pt_cache *cache, const char *img_path);
+int pt_stat_cache (const char *path, const char *img_path);
 
 /**
  * Get cached image info.
@@ -107,7 +82,32 @@ int pt_cache_status (struct pt_cache *cache, const char *img_path);
  * @return from pt_cache_header()
  * @return -PT_ERR_CACHE_STAT
  */
-int pt_cache_info (struct pt_cache *cache, struct pt_image_info *info);
+int pt_read_cache_info (const char *path, struct pt_image_info *info);
+
+/**
+ * Cache state
+ */
+struct pt_cache {
+    /** Filesystem path to cache file */
+    char *path;
+
+    /** Opened file */
+    int fd;
+
+    /** Size of the data segment in bytes, starting at PT_CACHE_HEADER_SIZE */
+    size_t data_size;
+
+    /** The mmap'd file */
+    struct pt_cache_file *file;
+
+    /** Opened read-only? */
+    bool readonly;
+};
+
+/**
+ * Construct the image cache info object associated with the given image.
+ */
+int pt_cache_new (struct pt_cache **cache_ptr, const char *path);
 
 /**
  * Update the cache data from the given PNG image data

--- a/src/lib/error.c
+++ b/src/lib/error.c
@@ -18,6 +18,7 @@ const char *error_names[PT_ERR_MAX] = {
 
     [PT_ERR_PNG_CREATE]         = "png_create()",
     [PT_ERR_PNG]                = "png_*()",
+    [PT_ERR_PNG_FORMAT]         = "Invalid PNG format",
 
     [PT_ERR_CACHE_MODE]         = "Invalid cache state",
     [PT_ERR_CACHE_STAT]         = "stat(.cache)",

--- a/src/lib/error.c
+++ b/src/lib/error.c
@@ -7,10 +7,9 @@ const char *error_names[PT_ERR_MAX] = {
     [PT_SUCCESS]                = "Success",
     [PT_ERR]                    = "Unspecified error",
     [PT_ERR_MEM]                = "malloc()",
+    [PT_ERR_PATH]               = "Invalid path",
 
-    [PT_ERR_PATH]               = "path",
-    [PT_ERR_OPEN_MODE]          = "open_mode",
-
+    [PT_ERR_IMG_MODE]             = "Invalid image state (open/close)",
     [PT_ERR_IMG_STAT]             = "stat(.png)",
     [PT_ERR_IMG_OPEN]             = "open(.png)",
     [PT_ERR_IMG_FORMAT]           = "Unknown image format",
@@ -20,6 +19,7 @@ const char *error_names[PT_ERR_MAX] = {
     [PT_ERR_PNG_CREATE]         = "png_create()",
     [PT_ERR_PNG]                = "png_*()",
 
+    [PT_ERR_CACHE_MODE]         = "Invalid cache state",
     [PT_ERR_CACHE_STAT]         = "stat(.cache)",
     [PT_ERR_CACHE_OPEN_READ]    = "open(.cache)",
     [PT_ERR_CACHE_UNLINK_TMP]   = "unlink(tmp)",

--- a/src/lib/image.c
+++ b/src/lib/image.c
@@ -96,28 +96,6 @@ int pt_image_info (struct pt_image *image, struct pt_image_info *info)
     return 0;
 }
 
-int pt_image_file_info (struct pt_image *image, const char *path, struct pt_file_info *info)
-{
-    struct stat st;
-    int err;
-
-    // verify that the path exists and looks like a valid file
-    if ((err = pt_sniff_image(path, &info->image.format)))
-        return err > 0 ? -PT_ERR_IMG_FORMAT : err;
-
-    if (stat(path, &st) < 0) {
-        return -PT_ERR_IMG_STAT;
-    }
-
-    // image file info
-    info->mtime = st.st_mtime;
-    info->bytes = st.st_size;
-
-    PT_DEBUG("%s: path=%s image bytes=%zu", image->cache_path, path, info->bytes);
-
-    return 0;
-}
-
 // Open source file
 static int pt_image_open_file (struct pt_image *image, const char *path, FILE **file_ptr)
 {

--- a/src/lib/image.c
+++ b/src/lib/image.c
@@ -82,16 +82,16 @@ int pt_image_status (struct pt_image *image, const char *path)
     return pt_stat_cache(image->cache_path, path);
 }
 
-int pt_image_info (struct pt_image *image, struct pt_image_info *info)
+int pt_image_info (struct pt_image *image, struct pt_cache_info *cache_info, struct pt_image_info *info)
 {
     int err;
 
     // update info from cache
-    if ((err = pt_read_cache_info(image->cache_path, info))) {
+    if ((err = pt_read_cache_info(image->cache_path, cache_info, info))) {
       return err;
     }
 
-    PT_DEBUG("%s: cache version=%d width=%d height=%d", image->cache_path, info->cache.version, info->width, info->height);
+    PT_DEBUG("%s: cache version=%d width=%d height=%d", image->cache_path, cache_info->version, info->width, info->height);
 
     return 0;
 }

--- a/src/lib/image.c
+++ b/src/lib/image.c
@@ -82,9 +82,8 @@ int pt_image_status (struct pt_image *image, const char *path)
     return pt_stat_cache(image->cache_path, path);
 }
 
-int pt_image_info (struct pt_image *image, const char *path, struct pt_image_info *info)
+int pt_image_info (struct pt_image *image, struct pt_image_info *info)
 {
-    struct stat st;
     int err;
 
     // update info from cache
@@ -92,23 +91,7 @@ int pt_image_info (struct pt_image *image, const char *path, struct pt_image_inf
       return err;
     }
 
-    PT_DEBUG("%s: cache version=%d width=%d height=%d", image->cache_path, info->cache_version, info->image_width, info->image_height);
-
-    if (path) {
-      // verify that the path exists and looks like a valid file
-      if ((err = pt_image_sniff(path, &info->image_format)))
-          return err > 0 ? -PT_ERR_IMG_FORMAT : err;
-
-      if (stat(path, &st) < 0) {
-          return -PT_ERR_IMG_STAT;
-      }
-
-      // image file info
-      info->image_mtime = st.st_mtime;
-      info->image_bytes = st.st_size;
-
-      PT_DEBUG("%s: path=%s image bytes=%zu", image->cache_path, path, info->image_bytes);
-    }
+    PT_DEBUG("%s: cache version=%d width=%d height=%d", image->cache_path, info->cache.version, info->width, info->height);
 
     return 0;
 }

--- a/src/lib/image.h
+++ b/src/lib/image.h
@@ -9,12 +9,10 @@
 #include "pngtile.h"
 
 struct pt_image {
-    enum pt_image_format format;
-    
-    /** Path to .png */
-    char *path;
+    /** Path to cache file */
+    char *cache_path;
 
-    /** Cache object */
+    /** Cache file */
     struct pt_cache *cache;
 };
 

--- a/src/lib/png.c
+++ b/src/lib/png.c
@@ -239,16 +239,6 @@ int pt_png_decode (struct pt_png_img *img, const struct pt_png_header *header, c
     return 0;
 }
 
-int pt_png_info (const struct pt_png_header *header, struct pt_image_info *info)
-{
-    // fill in info from header
-    info->image_width = header->width;
-    info->image_height = header->height;
-    info->image_bpp = header->bit_depth;
-
-    return 0;
-}
-
 /**
  * libpng I/O callback: write out data
  */

--- a/src/lib/png.c
+++ b/src/lib/png.c
@@ -10,7 +10,7 @@ const size_t pt_image_block_size = 64;
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 
-int pt_png_check (const char *path)
+int pt_sniff_png (const char *path)
 {
     FILE *fp;
     uint8_t header[8];

--- a/src/lib/png.h
+++ b/src/lib/png.h
@@ -50,7 +50,7 @@ struct pt_png_header {
  *
  * Returns 0 if ok, 1 if non-png file, -1 on error
  */
-int pt_png_check (const char *path);
+int pt_sniff_png (const char *path);
 
 /**
  * Open the given .png image, and read info

--- a/src/lib/png.h
+++ b/src/lib/png.h
@@ -68,11 +68,6 @@ int pt_png_read_header (struct pt_png_img *img, struct pt_png_header *header, si
 int pt_png_decode (struct pt_png_img *img, const struct pt_png_header *header, const struct pt_image_params *params, uint8_t *out);
 
 /**
- * Fill in img_* fields of pt_image_info from cache png header
- */
-int pt_png_info (const struct pt_png_header *header, struct pt_image_info *info);
-
-/**
  * Render out a tile
  */
 int pt_png_tile (const struct pt_png_header *header, const uint8_t *data, struct pt_tile *tile);

--- a/src/lib/png.h
+++ b/src/lib/png.h
@@ -43,6 +43,23 @@ struct pt_png_header {
     png_color palette[PNG_MAX_PALETTE_LENGTH];
 };
 
+static inline size_t pt_png_data_size (const struct pt_png_header *header)
+{
+  // calculate data size
+  return header->height * (size_t)header->row_bytes;
+}
+
+/**
+ * Decode target.
+ */
+struct pt_png_out {
+  const struct pt_png_header *header;
+
+  uint8_t *data;
+
+  unsigned row, col; // pixels
+};
+
 #include "tile.h"
 
 /**
@@ -56,6 +73,11 @@ int pt_sniff_png (const char *path);
  * Read basic image metadata.
  */
 int pt_read_png_info (const char *path, struct pt_image_info *info);
+
+/**
+ * Scale PNG header for mutli-part image.
+ */
+ int pt_read_parts_png_header (const struct pt_image_parts *parts, struct pt_png_header *header, struct pt_png_header *part_header);
 
 /**
  * Open the given .png image file.
@@ -75,12 +97,12 @@ int pt_png_read_info (struct pt_png_img *img, struct pt_image_info *info);
 /**
  * Fill in the PNG header and return the size of the pixel data
  */
-int pt_png_read_header (struct pt_png_img *img, struct pt_png_header *header, size_t *data_size);
+ int pt_png_read_header (struct pt_png_img *img, struct pt_png_header *header);
 
 /**
  * Decode the PNG data into the given data segment, using the header as decoded by pt_png_read_header
  */
-int pt_png_decode (struct pt_png_img *img, const struct pt_png_header *header, const struct pt_image_params *params, uint8_t *out);
+int pt_png_decode (struct pt_png_img *img, const struct pt_png_header *header, const struct pt_image_params *params, const struct pt_png_out *out);
 
 /**
  * Render out a tile

--- a/src/lib/png.h
+++ b/src/lib/png.h
@@ -53,9 +53,24 @@ struct pt_png_header {
 int pt_sniff_png (const char *path);
 
 /**
- * Open the given .png image, and read info
+ * Read basic image metadata.
+ */
+int pt_read_png_info (const char *path, struct pt_image_info *info);
+
+/**
+ * Open the given .png image file.
+ */
+int pt_png_open_path (struct pt_png_img *img, const char *path);
+
+/**
+ * Read PNG from given file.
  */
 int pt_png_open (struct pt_png_img *img, FILE *file);
+
+/**
+ * Read basic info from PNG header.
+ */
+int pt_png_read_info (struct pt_png_img *img, struct pt_image_info *info);
 
 /**
  * Fill in the PNG header and return the size of the pixel data

--- a/src/pngtile/main.c
+++ b/src/pngtile/main.c
@@ -354,15 +354,16 @@ int main (int argc, char **argv)
 
         // show info
         struct pt_image_info info;
+        struct pt_cache_info cache_info;
 
-        if ((err = pt_image_info(image, &info))) {
+        if ((err = pt_image_info(image, &cache_info, &info))) {
             log_warn_errno("pt_image_info: %s", pt_strerror(err));
 
         } else {
             log_info("\tImage dimensions: %zux%zu (%zu bpp)", info.width, info.height, info.bpp);
             //log_info("\tImage mtime=%ld, bytes=%zu", (long) info.image_mtime, info.image_bytes);
             log_info("\tCache mtime=%ld, bytes=%zu, blocks=%zu (%zu bytes), version=%d",
-                    (long) info.cache.mtime, info.cache.bytes, info.cache.blocks, info.cache.blocks * 512, info.cache.version
+                    (long) cache_info.mtime, cache_info.bytes, cache_info.blocks, cache_info.blocks * 512, cache_info.version
             );
         }
 

--- a/src/pngtile/main.c
+++ b/src/pngtile/main.c
@@ -109,8 +109,8 @@ long randrange (long start, long end)
  */
 void randomize_tile (struct pt_tile_params *params, const struct pt_image_info *info)
 {
-    params->x = randrange(0, info->image_width - params->width);
-    params->y = randrange(0, info->image_height - params->height);
+    params->x = randrange(0, info->width - params->width);
+    params->y = randrange(0, info->height - params->height);
 }
 
 /**
@@ -355,14 +355,14 @@ int main (int argc, char **argv)
         // show info
         struct pt_image_info info;
 
-        if ((err = pt_image_info(image, img_path, &info))) {
-            log_warn_errno("pt_image_info: %s: %s", img_path, pt_strerror(err));
+        if ((err = pt_image_info(image, &info))) {
+            log_warn_errno("pt_image_info: %s", pt_strerror(err));
 
         } else {
-            log_info("\tImage dimensions: %zux%zu (%zu bpp)", info.image_width, info.image_height, info.image_bpp);
-            log_info("\tImage mtime=%ld, bytes=%zu", (long) info.image_mtime, info.image_bytes);
+            log_info("\tImage dimensions: %zux%zu (%zu bpp)", info.width, info.height, info.bpp);
+            //log_info("\tImage mtime=%ld, bytes=%zu", (long) info.image_mtime, info.image_bytes);
             log_info("\tCache mtime=%ld, bytes=%zu, blocks=%zu (%zu bytes), version=%d",
-                    (long) info.cache_mtime, info.cache_bytes, info.cache_blocks, info.cache_blocks * 512, info.cache_version
+                    (long) info.cache.mtime, info.cache.bytes, info.cache.blocks, info.cache.blocks * 512, info.cache.version
             );
         }
 


### PR DESCRIPTION
Allow updating a single `.cache` file from a collection of tiled `*_x_y.png` images.